### PR TITLE
put sockets in /socket dir

### DIFF
--- a/include/cutils/sockets.h
+++ b/include/cutils/sockets.h
@@ -41,7 +41,7 @@ typedef int cutils_socket_t;
 #endif
 
 #define ANDROID_SOCKET_ENV_PREFIX	"ANDROID_SOCKET_"
-#define ANDROID_SOCKET_DIR		"/dev/socket"
+#define ANDROID_SOCKET_DIR		"/socket"
 
 #ifdef __cplusplus
 extern "C" {

--- a/init/init.cpp
+++ b/init/init.cpp
@@ -503,6 +503,7 @@ int main(int argc, char** argv) {
     if (is_first_stage) {
         mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755");
         mkdir("/dev/pts", 0755);
+        mkdir("/socket", 0755);
         mkdir("/dev/socket", 0755);
         mount("devpts", "/dev/pts", "devpts", 0, NULL);
         #define MAKE_STR(x) __STRING(x)


### PR DESCRIPTION
It's umm rather awkward bug, to share sockets between host and android
container, we do following

- Create /dev/socket in the host
- Create $ANDROID_ROOT/socket
- Bind this two directories before starting the android
- Patch the android init.rc to bind /socket in the /dev/socket in
early-init stage

This worked perfectly fine in Android 5, however in android 7,
/dev/socket/property_service is created before early-init stage. This
results in our command bind mounting empty /socket dir on top of
/dev/socket and later android not being able to find property socket.

Change-Id: Id27afc234f7287d043850c0c384fbb588c0744eb