### PR TITLE
Add sensorservice to input, log, compass groups

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -683,4 +683,4 @@ service flash_recovery /system/bin/install-recovery.sh
 service sensorservice /system/bin/sensorservice
     class main
     user system
-    group system
+    group system input log compass


### PR DESCRIPTION
In normal Android 7.1 sensorservice runs as part of system_server, which has access to more groups than just system, for example on mine device:

Groups: 1001 1002 1003 1004 1005 1006 1007 1008 1009 1010 1018 1021 1032 3001 3002 3003 3006 3007 3009 3010

This commit adds sensorservice to the groups considered "reasonable" for accessing sensors.
The change fixes it on Moto Z Play (addison), where some sensor devices are owned by "compass" group.