### PR TITLE
init: Handle udev event peaks

### DIFF
--- a/init/devices.cpp
+++ b/init/devices.cpp
@@ -1098,8 +1098,11 @@ void device_init() {
     sehandle = selinux_android_file_context_handle();
     selinux_status_open(true);
 
-    /* is 256K enough? udev uses 16MB! */
-    device_fd = uevent_open_socket(256*1024, true);
+    /* There can be peaks of udev events on boot that require a big buffer, so
+     * we use here the maximum possible size. Note that the memory is not
+     * actually allocated unless it is really needed. This is the same udevd
+     * does. */
+    device_fd = uevent_open_socket(128*1024*1024, true);
     if (device_fd == -1) {
         return;
     }

--- a/init/ueventd.cpp
+++ b/init/ueventd.cpp
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 
 #include <android-base/stringprintf.h>
 #include <private/android_filesystem_config.h>
@@ -81,8 +82,12 @@ int ueventd_main(int argc, char **argv)
             continue;
         }
         if (ufd.revents & POLLERR) {
-               ERROR("got POLLERR, terminating ueventd\n");
-               exit(1);
+            int error = 0;
+            socklen_t errlen = sizeof(error);
+
+            getsockopt(ufd.fd, SOL_SOCKET, SO_ERROR, (void *) &error, &errlen);
+            ERROR("got POLLERR, terminating ueventd: SO_ERROR is %d\n", error);
+            exit(1);
         }
         if (ufd.revents & POLLIN) {
             handle_device_fd();


### PR DESCRIPTION
There were peaks of udev events that made poll fail with POLLERR, being
the socket error ENOBUFS. This made ueventd exit. We increase the
buffer size to the maximum possible to avoid this. This is the same
udev does (see https://bugzilla.redhat.com/show_bug.cgi?id=655857).
Fixes LP #1543278.

Change-Id: Iac67738fc5d19ddee559159428fa7033ba0a8fce
Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

----------------------------------------------------------------------------------

This fixes firmware loading, as it prevents dropping firmware requests from the kernel. This prevents unity-system-compositor from crashing in FP2.