### PR TITLE
init: Set compatibility symlink at /dev/socket

### DIFF
--- a/init/init.cpp
+++ b/init/init.cpp
@@ -504,7 +504,7 @@ int main(int argc, char** argv) {
         mount("tmpfs", "/dev", "tmpfs", MS_NOSUID, "mode=0755");
         mkdir("/dev/pts", 0755);
         mkdir("/socket", 0755);
-        mkdir("/dev/socket", 0755);
+        symlink("/socket", "/dev/socket");
         mount("devpts", "/dev/pts", "devpts", 0, NULL);
         #define MAKE_STR(x) __STRING(x)
         mount("proc", "/proc", "proc", 0, "hidepid=2,gid=" MAKE_STR(AID_READPROC));


### PR DESCRIPTION
This is required for recovery images to boot successfully.