### PR TITLE
get rid of droid-hybris

### DIFF
--- a/init/builtins.cpp
+++ b/init/builtins.cpp
@@ -392,7 +392,7 @@ static void import_late(const std::vector<std::string>& args, size_t start_index
     if (end_index <= start_index) {
         // Fallbacks for partitions on which early mount isn't enabled.
         if (!parser.is_system_etc_init_loaded()) {
-            parser.ParseConfig("/usr/libexec/droid-hybris/system/etc/init");
+            parser.ParseConfig("/system/etc/init");
             parser.set_is_system_etc_init_loaded(true);
         }
         if (!parser.is_vendor_etc_init_loaded()) {


### PR DESCRIPTION
/usr/libexec/droid-hybris/ is only used with SailfishOS, not with Halium

Change-Id: Ie1c41b2dc145b5c6f8d6270e86074f2a3352ec0a